### PR TITLE
Compilation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ gcc -m32 -c kernel.c -o kc.o
 ld -m elf_i386 -T link.ld -o kernel kasm.o kc.o
 ```
 
+If you get the following error message:
+```
+kc.o: In function `idt_init':
+kernel.c:(.text+0x129): undefined reference to `__stack_chk_fail'
+```
+
+compile with the `-fno-stack-protector` option:
+```
+gcc -fno-stack-protector -m32 -c kernel.c -o bin/kc.o
+```
+
 ####Test on emulator####
 ```
 qemu-system-i386 -kernel kernel


### PR DESCRIPTION
Some versions of gcc protect the stack, and so the code does not compile. By adding the `-fno-stack-protector` option, the problem is solved.